### PR TITLE
FEAT: Allows one to specify ARNs as lists

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,14 +28,19 @@ module "permissions" {
 
   sqs_queues = [
     {
-      arn = data.aws_sqs_queue.arn
+      arns = [
+        data.aws_sqs_queue.arn,
+        data.aws_sqs_queue_two.arn
+      ]
       permissions = ["receive", "delete", "send"]
     }
   ]
 
   sns_topics = [
     {
-      arn = data.aws_sns_topic.arn
+      arns = [
+        data.aws_sns_topic.arn
+      ]
       permissions = ["subscription", "publish"]
     }
   ]

--- a/main.tf
+++ b/main.tf
@@ -21,16 +21,16 @@ module "sqs_queue" {
   default_permissions = ["sqs:GetQueueAttributes"]
   explicit_permissions = {
     receive = ["sqs:ReceiveMessage"]
-    send = ["sqs:SendMessage"]
-    delete = ["sqs:DeleteMessage"]
+    send    = ["sqs:SendMessage"]
+    delete  = ["sqs:DeleteMessage"]
   }
 
-  for_each = { for value in var.sqs_queues : value.arn => value.permissions }
+  for_each = { for value in var.sqs_queues : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = [each.key]
-  permissions = each.value
+  resource_arns = each.key
+  permissions   = each.value
 }
 
 /*
@@ -52,12 +52,12 @@ module "sns_topic" {
     ]
   }
 
-  for_each = { for value in var.sns_topics : value.arn => value.permissions }
+  for_each = { for value in var.sns_topics : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = [each.key]
-  permissions = each.value
+  resource_arns = each.key
+  permissions   = each.value
 }
 
 /*
@@ -69,7 +69,7 @@ module "sns_topic" {
 module "s3_bucket" {
   source = "./modules/policy"
 
-  default_permissions  = [
+  default_permissions = [
     # Allow users to see which region the bucket is in.
     # There isn't really any risk to this.
     "s3:GetBucketLocation",
@@ -92,12 +92,12 @@ module "s3_bucket" {
     ]
   }
 
-  for_each = {for value in var.s3_buckets : value.arn => value.permissions}
+  for_each = { for value in var.s3_buckets : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = concat([each.key], formatlist("%s/*", [each.key]))
-  permissions  = each.value
+  resource_arns = concat(each.key, formatlist("%s/*", each.key))
+  permissions   = each.value
 }
 
 /*
@@ -109,7 +109,7 @@ module "s3_bucket" {
 module "dynamodb_table" {
   source = "./modules/policy"
 
-  default_permissions  = []
+  default_permissions = []
   explicit_permissions = {
     get = [
       "dynamodb:GetItem",
@@ -127,12 +127,12 @@ module "dynamodb_table" {
     ]
   }
 
-  for_each = {for value in var.dynamodb_tables : value.arn => value.permissions}
+  for_each = { for value in var.dynamodb_tables : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = [each.key]
-  permissions  = each.value
+  resource_arns = each.key
+  permissions   = each.value
 }
 
 /*
@@ -144,7 +144,7 @@ module "dynamodb_table" {
 module "kms_key" {
   source = "./modules/policy"
 
-  default_permissions  = [
+  default_permissions = [
     # Allow for services to see details about the key.
     # Shouldn't really give any surface area.
     "kms:DescribeKey"
@@ -161,12 +161,12 @@ module "kms_key" {
     ]
   }
 
-  for_each = {for value in var.kms_keys : value.arn => value.permissions}
+  for_each = { for value in var.kms_keys : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = [each.key]
-  permissions  = each.value
+  resource_arns = each.key
+  permissions   = each.value
 }
 
 /*
@@ -178,7 +178,7 @@ module "kms_key" {
 module "ssm_parameter_store" {
   source = "./modules/policy"
 
-  default_permissions  = []
+  default_permissions = []
   explicit_permissions = {
     get = [
       "ssm:GetParameters",
@@ -197,12 +197,12 @@ module "ssm_parameter_store" {
     ]
   }
 
-  for_each = {for value in var.ssm_parameters : value.arn => value.permissions}
+  for_each = { for value in var.ssm_parameters : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = [each.key]
-  permissions  = each.value
+  resource_arns = each.key
+  permissions   = each.value
 }
 
 /*
@@ -217,7 +217,7 @@ module "ssm_parameter_store" {
 module "cloudwatch_metrics" {
   source = "./modules/policy"
 
-  default_permissions  = []
+  default_permissions = []
   explicit_permissions = {
     get = [
       "cloudwatch:GetMetricData",
@@ -229,12 +229,12 @@ module "cloudwatch_metrics" {
     ]
   }
 
-  for_each = {for value in var.cloudwatch_metrics : value.arn => value.permissions}
+  for_each = { for value in var.cloudwatch_metrics : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = [each.key]
-  permissions  = each.value
+  resource_arns = each.key
+  permissions   = each.value
 }
 
 /*
@@ -246,7 +246,7 @@ module "cloudwatch_metrics" {
 module "secrets_manager" {
   source = "./modules/policy"
 
-  default_permissions  = [
+  default_permissions = [
   ]
   explicit_permissions = {
     get = [
@@ -272,10 +272,10 @@ module "secrets_manager" {
     ]
   }
 
-  for_each = {for value in var.secrets_manager : value.arn => value.permissions}
+  for_each = { for value in var.secrets_manager : value.arns => value.permissions }
 
   role_name = var.role_name
 
-  resource_arns = [each.key]
-  permissions  = each.value
+  resource_arns = each.key
+  permissions   = each.value
 }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ module "sqs_queue" {
     delete  = ["sqs:DeleteMessage"]
   }
 
-  for_each = var.sqs_queues
+  for_each = toset(var.sqs_queues)
 
   role_name = var.role_name
 
@@ -52,7 +52,7 @@ module "sns_topic" {
     ]
   }
 
-  for_each = var.sns_topics
+  for_each = toset(var.sns_topics)
 
   role_name = var.role_name
 
@@ -92,7 +92,7 @@ module "s3_bucket" {
     ]
   }
 
-  for_each = var.s3_buckets
+  for_each = toset(var.s3_buckets)
 
   role_name = var.role_name
 
@@ -127,7 +127,7 @@ module "dynamodb_table" {
     ]
   }
 
-  for_each = var.dynamodb_tables
+  for_each = toset(var.dynamodb_tables)
 
   role_name = var.role_name
 
@@ -161,7 +161,7 @@ module "kms_key" {
     ]
   }
 
-  for_each = var.kms_keys
+  for_each = toset(var.kms_keys)
 
   role_name = var.role_name
 
@@ -197,7 +197,7 @@ module "ssm_parameter_store" {
     ]
   }
 
-  for_each = var.ssm_parameters
+  for_each = toset(var.ssm_parameters)
 
   role_name = var.role_name
 
@@ -229,7 +229,7 @@ module "cloudwatch_metrics" {
     ]
   }
 
-  for_each = var.cloudwatch_metrics
+  for_each = toset(var.cloudwatch_metrics)
 
   role_name = var.role_name
 
@@ -272,7 +272,7 @@ module "secrets_manager" {
     ]
   }
 
-  for_each = var.secrets_manager
+  for_each = toset(var.secrets_manager)
 
   role_name = var.role_name
 

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ module "sqs_queue" {
     delete  = ["sqs:DeleteMessage"]
   }
 
-  for_each = toset(var.sqs_queues)
+  for_each = { for value in var.sqs_queues : index(var.sqs_queues, value) => value }
 
   role_name = var.role_name
 
@@ -52,7 +52,7 @@ module "sns_topic" {
     ]
   }
 
-  for_each = toset(var.sns_topics)
+  for_each = { for value in var.sns_topics : index(var.sns_topics, value) => value }
 
   role_name = var.role_name
 
@@ -92,7 +92,7 @@ module "s3_bucket" {
     ]
   }
 
-  for_each = toset(var.s3_buckets)
+  for_each = { for value in var.s3_buckets : index(var.s3_buckets, value) => value }
 
   role_name = var.role_name
 
@@ -127,7 +127,7 @@ module "dynamodb_table" {
     ]
   }
 
-  for_each = toset(var.dynamodb_tables)
+  for_each = { for value in var.dynamodb_tables : index(var.dynamodb_tables, value) => value }
 
   role_name = var.role_name
 
@@ -161,7 +161,7 @@ module "kms_key" {
     ]
   }
 
-  for_each = toset(var.kms_keys)
+  for_each = { for value in var.kms_keys : index(var.kms_keys, value) => value }
 
   role_name = var.role_name
 
@@ -197,7 +197,7 @@ module "ssm_parameter_store" {
     ]
   }
 
-  for_each = toset(var.ssm_parameters)
+  for_each = { for value in var.ssm_parameters : index(var.ssm_parameters, value) => value }
 
   role_name = var.role_name
 
@@ -229,7 +229,7 @@ module "cloudwatch_metrics" {
     ]
   }
 
-  for_each = toset(var.cloudwatch_metrics)
+  for_each = { for value in var.cloudwatch_metrics : index(var.cloudwatch_metrics, value) => value }
 
   role_name = var.role_name
 
@@ -272,7 +272,7 @@ module "secrets_manager" {
     ]
   }
 
-  for_each = toset(var.secrets_manager)
+  for_each = { for value in var.secrets_manager : index(var.secrets_manager, value) => value }
 
   role_name = var.role_name
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.0.0"
+      version = ">= 3.0.0, < 4.0.0"
     }
   }
 }
@@ -25,12 +25,12 @@ module "sqs_queue" {
     delete  = ["sqs:DeleteMessage"]
   }
 
-  for_each = { for value in var.sqs_queues : value.arns => value.permissions }
+  for_each = var.sqs_queues
 
   role_name = var.role_name
 
-  resource_arns = each.key
-  permissions   = each.value
+  resource_arns = each.value.arns
+  permissions   = each.value.permissions
 }
 
 /*
@@ -52,12 +52,12 @@ module "sns_topic" {
     ]
   }
 
-  for_each = { for value in var.sns_topics : value.arns => value.permissions }
+  for_each = var.sns_topics
 
   role_name = var.role_name
 
-  resource_arns = each.key
-  permissions   = each.value
+  resource_arns = each.value.arns
+  permissions   = each.value.permissions
 }
 
 /*
@@ -92,12 +92,12 @@ module "s3_bucket" {
     ]
   }
 
-  for_each = { for value in var.s3_buckets : value.arns => value.permissions }
+  for_each = var.s3_buckets
 
   role_name = var.role_name
 
-  resource_arns = concat(each.key, formatlist("%s/*", each.key))
-  permissions   = each.value
+  resource_arns = concat(each.value.arns, formatlist("%s/*", each.value.arns))
+  permissions   = each.value.permissions
 }
 
 /*
@@ -127,12 +127,12 @@ module "dynamodb_table" {
     ]
   }
 
-  for_each = { for value in var.dynamodb_tables : value.arns => value.permissions }
+  for_each = var.dynamodb_tables
 
   role_name = var.role_name
 
-  resource_arns = each.key
-  permissions   = each.value
+  resource_arns = each.value.arns
+  permissions   = each.value.permissions
 }
 
 /*
@@ -161,12 +161,12 @@ module "kms_key" {
     ]
   }
 
-  for_each = { for value in var.kms_keys : value.arns => value.permissions }
+  for_each = var.kms_keys
 
   role_name = var.role_name
 
-  resource_arns = each.key
-  permissions   = each.value
+  resource_arns = each.value.arns
+  permissions   = each.value.permissions
 }
 
 /*
@@ -197,12 +197,12 @@ module "ssm_parameter_store" {
     ]
   }
 
-  for_each = { for value in var.ssm_parameters : value.arns => value.permissions }
+  for_each = var.ssm_parameters
 
   role_name = var.role_name
 
-  resource_arns = each.key
-  permissions   = each.value
+  resource_arns = each.value.arns
+  permissions   = each.value.permissions
 }
 
 /*
@@ -229,12 +229,12 @@ module "cloudwatch_metrics" {
     ]
   }
 
-  for_each = { for value in var.cloudwatch_metrics : value.arns => value.permissions }
+  for_each = var.cloudwatch_metrics
 
   role_name = var.role_name
 
-  resource_arns = each.key
-  permissions   = each.value
+  resource_arns = each.value.arns
+  permissions   = each.value.permissions
 }
 
 /*
@@ -272,10 +272,10 @@ module "secrets_manager" {
     ]
   }
 
-  for_each = { for value in var.secrets_manager : value.arns => value.permissions }
+  for_each = var.secrets_manager
 
   role_name = var.role_name
 
-  resource_arns = each.key
-  permissions   = each.value
+  resource_arns = each.value.arns
+  permissions   = each.value.permissions
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
 variable "role_name" {
   description = "The role to attach the permissions to"
-  type = string
+  type        = string
 }
 
 variable "sqs_queues" {
   description = "Permissions for SQS resources"
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 
@@ -16,7 +16,7 @@ variable "sqs_queues" {
 variable "sns_topics" {
   description = "Permissions for SNS Topics"
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 
@@ -26,7 +26,7 @@ variable "sns_topics" {
 variable "s3_buckets" {
   description = "Permissions for S3 buckets"
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 
@@ -36,7 +36,7 @@ variable "s3_buckets" {
 variable "dynamodb_tables" {
   description = "Permissions for DynamoDB Tables"
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 
@@ -46,7 +46,7 @@ variable "dynamodb_tables" {
 variable "kms_keys" {
   description = "Permissions for KMS Keys"
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 
@@ -56,7 +56,7 @@ variable "kms_keys" {
 variable "ssm_parameters" {
   description = "Permissions for SSM Parameters"
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 
@@ -66,7 +66,7 @@ variable "ssm_parameters" {
 variable "cloudwatch_metrics" {
   description = "Permissions for CloudWatch Metrics. These endpoints don't care about the ARN, so * is recommended."
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 
@@ -76,7 +76,7 @@ variable "cloudwatch_metrics" {
 variable "secrets_manager" {
   description = "Permissions for Secrets Manager"
   type = list(object({
-    arn = string
+    arns        = list(string)
     permissions = list(string)
   }))
 


### PR DESCRIPTION
This means you no longer have to make separate
specifications for each resource. Very often one
wants the exact same permissions for different
resources of the same types. As AWS policies
already use lists for resource IDs, this module
should reflect that.

README has been updated. A caveat here is that
existing users needs to update from using arn to
using arns as the parameter name, and also change
to sending in a list instead of singular
identifiers.

Lastly formatted the TF files.