### PR TITLE
FEAT: Add ListBucketVersions to blanket s3 allow.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,8 @@ module "s3_bucket" {
     # Though it does potentially give a malicious actor the ability to see what
     # kind of data is in the bucket. However, this is such a small risk, that
     # we'll blanket allow it.
-    "s3:ListBucket"
+    "s3:ListBucket",
+    "s3:ListBucketVersions"
   ]
   explicit_permissions = {
     get = [


### PR DESCRIPTION
Adds ListBucketVersions as a common S3 permission to solve issue where GETing a non-existing object in a versioned bucket returned 403 (access denied) instead of 404 (not found).