### PR TITLE
Add sqs:StartMessageMoveTask

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -60,6 +60,8 @@ Here are all the services and permissions.
 |Send messages to the queue
 |`delete`
 |Delete messages from the queue
+|`move`
+|Start a message move task for the queue
 
 1.2+|`sns_topics`
 1.2+|None

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ module "sqs_queue" {
     receive = ["sqs:ReceiveMessage"]
     send    = ["sqs:SendMessage"]
     delete  = ["sqs:DeleteMessage"]
+    move    = ["sqs:StartMessageMoveTask"]
   }
 
   role_name = var.role_name


### PR DESCRIPTION
Add `sqs:StartMessageMoveTask` as permission option for sqs permissions. Used to redrive messages from DLQ.